### PR TITLE
Tag annotations with author and date

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,12 +890,14 @@ you need to comment out a particular form.
   describing the problem.
 * If multiple lines are required to describe the problem, subsequent
   lines should be indented as much as the first one.
+* Tag the annotation with your initials and a date so its relevance can
+  be easily verified.
 
     ```Clojure
     (defn some-fun
       []
       ;; FIXME: This has crashed occasionally since v1.2.3. It may
-      ;;        be related to the BarBazUtil upgrade.
+      ;;        be related to the BarBazUtil upgrade. (xz 13-1-31)
       (baz))
     ```
 


### PR DESCRIPTION
Tagging annotations this way makes them much more useful in practise because by its age it's easy to determine its relevance, and because it's attributed it is easy to go to the person who made the annotation for clarification if needed. Git blame can be used for this but can take substantially more effort.
