### PR TITLE
Prefer :require over :use in ns macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,18 @@ pairwise constructs as found in e.g. `let` and `cond`.
                                      LinkedBlockingQueue)))
     ```
 
+* Prefer using `:require :refer :all` over `:use` in ns macro.
+
+    ```Clojure
+    ;; good
+    (ns examlpes.ns
+        (:require [clojure.zip :refer :all]))
+
+    ;; bad
+    (ns examlpes.ns
+        (:use [clojure.zip]))
+    ```
+
 * Avoid single-segment namespaces.
 
     ```Clojure


### PR DESCRIPTION
There was a lot of arguing about `:require` vs `:use` in clojure mailing list, but as far as I know `:require` with `:refer` is still preferable over `:use` since having one thing to do code loading and refering vars is simpler. But `:use` not officially deprecated yet.
