### PR TITLE
more explanation why you'd do such a thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ pairwise constructs as found in e.g. `let` and `cond`.
                                      LinkedBlockingQueue]))
     ```
 
-* Prefer using `:require :refer :all` over `:use` in ns macro.
+* If you want to refer to names without having to qualify them with any
+  namespace at all, prefer using `:require :refer :all` over `:use` in ns macro.
 
     ```Clojure
     ;; good


### PR DESCRIPTION
Though, I think the guideline would be even better if it mentioned that, as a kindness to your readers, it's easy enough to just alias your namespace to a letter or two, ex. `(ns examples.ns (:require [clojure.zip :as z)`.