### PR TITLE
Fix ns example

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ pairwise constructs as found in e.g. `let` and `cond`.
 
     ;; bad
     (ns examples.ns
-      (:use [clojure.zip]))
+      (:use clojure.zip))
     ```
 
 * Avoid single-segment namespaces.


### PR DESCRIPTION
I fixed `ns` example.
1. Fix typo (examlpes -> examples)
2. Remove unnecessary brackets
