### PR TITLE
fix ns statements trailing parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,9 @@ pairwise constructs as found in e.g. `let` and `cond`.
       (:import java.util.Date
                java.text.SimpleDateFormat
                [java.util.concurrent Executors
-                                     LinkedBlockingQueue]))
+                                     LinkedBlockingQueue]
+      )
+    )
     ```
 
 * Prefer using `:require :refer :all` over `:use` in ns macro.
@@ -268,11 +270,13 @@ pairwise constructs as found in e.g. `let` and `cond`.
     ```Clojure
     ;; good
     (ns examples.ns
-      (:require [clojure.zip :refer :all]))
+      (:require [clojure.zip :refer :all])
+    )
 
     ;; bad
     (ns examples.ns
-      (:use clojure.zip))
+      (:use clojure.zip)
+    )
     ```
 
 * Avoid single-segment namespaces.


### PR DESCRIPTION
The ns statements were breaking the rules of this styleguide concerning the trailing parentheses. I put them each in their own line. I think you shouldn't propose a rule in one part of the document and then break it in the next paragraph, right? Should this also be fixed in the above defn statements?
