### PR TITLE
Removes excess indentation around git config autocrlf line

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ You can generate a PDF or an HTML copy of this guide using
     configuration setting to protect your project from Windows line
     endings creeping in:
 
-        ```bash
-        $ git config --global core.autocrlf true
-        ```
+    ```
+    bash$ git config --global core.autocrlf true
+    ```
 
 * If any text precedes an opening bracket(`(`, `{` and
 `[`) or follows a closing bracket(`)`, `}` and `]`), separate that


### PR DESCRIPTION
The suggested git config for autocrlf is rendering with graves in the code box because it is both indented and wrapped with triple graves.

``````
    ```bash
    $ git config --global core.autocrlf true
    ```
``````

With the extra indentation removed it now renders correctly.

```
bash$ git config --global core.autocrlf true
```

Thanks for putting this together everyone!
