### PR TITLE
:else for conditions: remove condp (won't work)

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ pairwise constructs as found in e.g. `let` and `cond`.
     (.. System getProperties (get "os.name"))
     ```
 
-* Use `:else` as the catch-all test expression in `cond` and `condp`.
+* Use `:else` as the catch-all test expression in `cond`.
 
     ```Clojure
     ;; good


### PR DESCRIPTION
`condp` can't usually take an `:else` label for its default since it's rare that the predicate would happen to evaluate to `true` for `:else` --- as demonstrated by the next example which uses `condp` with an unlabelled default.
