### PR TITLE
Style: indentation of multiple-arity functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ You can generate a PDF or an HTML copy of this guide using
     (defn foo
       ([x] (bar x))
       ([x y]
-        (if (predicate? x)
-          (bar x)
-          (baz x))))
+       (if (predicate? x)
+         (bar x)
+         (baz x))))
 
     ;; bad
     (defn foo
@@ -147,6 +147,28 @@ You can generate a PDF or an HTML copy of this guide using
             (bar x)
             (baz x)))
     ```
+
+* <a name="multiple-arity-indentation"></a>
+  Indent each arity form of a function definition vertically aligned with its
+  parameters.<sup>[[link](#multiple-arity-indentation)]</sup>
+
+```Clojure
+;; good
+(defn foo
+  "I have two arities."
+  ([x]
+   (foo x 1))
+  ([x y]
+   (+ x y)))
+
+;; bad - extra indentation
+(defn foo
+  "I have two arities."
+  ([x]
+    (foo x 1))
+  ([x y]
+    (+ x y)))
+```
 
 * <a name="align-docstring-lines"></a>
   Indent each line of multi-line docstrings.


### PR DESCRIPTION
This pull request adds guidelines on how to indent multiple-artity functions. The exact style here is to vertically align arguments and function body - as elements of any sequence would be indented; however this is up for discussion as there is no de facto agreement on how to indent these forms. Different tools have arbitrarily chosen different indentation styles and it would be good to reach an agreement on what most people prefer so that we can all conform to a consistent code style.
