### PR TITLE
No reason to avoid single-segment namespaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,18 +389,6 @@ pairwise constructs as found in e.g. `let` and `cond`.
       (:use clojure.zip))
     ```
 
-* <a name="no-single-segment-namespaces"></a>
-  Avoid single-segment namespaces.
-<sup>[[link](#no-single-segment-namespaces)]</sup>
-
-    ```Clojure
-    ;; good
-    (ns example.ns)
-
-    ;; bad
-    (ns example)
-    ```
-
 * <a name="namespaces-with-5-segments-max"></a>
   Avoid the use of overly long namespaces (i.e., more than 5 segments).
 <sup>[[link](#namespaces-with-5-segments-max)]</sup>


### PR DESCRIPTION
Clojure namespaces with `gen-class` map to classes with the same full name as the namespace.  This produced some concern about single-segment namespaces being equivalent to Java package-less classes and a cargo-culting avoidance of single-segment namespaces.  In practice non-`gen-class` single-segment namespaces do not appear to cause any known problems, and have begun to appear in libraries by well-respected Clojure community members, such as Brandom Bloom’s backtick [1].

[1] https://github.com/brandonbloom/backtick
