### PR TITLE
No evidence for preferring `..` to `->`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,18 +741,6 @@ pairwise constructs as found in e.g. `let` and `cond`.
          (filter even? (range 1 10)))
     ```
 
-* <a name="dot-dot-macro"></a>
-  Prefer `..` to `->` when chaining method calls in Java interop.
-<sup>[[link](#dot-dot-macro)]</sup>
-
-    ```Clojure
-    ;; good
-    (-> (System/getProperties) (.get "os.name"))
-
-    ;; better
-    (.. System getProperties (get "os.name"))
-    ```
-
 * <a name="else-keyword-in-cond"></a>
   Use `:else` as the catch-all test expression in `cond`.
 <sup>[[link](#else-keyword-in-cond)]</sup>


### PR DESCRIPTION
In my Clojure software archaeology corpus, I see no consistent evidence of the community preferring `..` for chaining interop forms.  I count 155 forms using `..` and 146 forms using `->` with interop.  The use of `..` seems to be a matter of individual taste and not of community style.