### PR TITLE
Set predicate `#{0}` -> `#{1}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,10 +857,10 @@ hints for the pairwise grouping with comments or empty lines.
 
     ```Clojure
     ;; good
-    (remove #{0} [0 1 2 3 4 5])
+    (remove #{1} [0 1 2 3 4 5])
 
     ;; bad
-    (remove #(= % 0) [0 1 2 3 4 5])
+    (remove #(= % 1) [0 1 2 3 4 5])
 
     ;; good
     (count (filter #{\a \e \i \o \u} "mary had a little lamb"))


### PR DESCRIPTION
The set `#{0}` is a suboptimal example because the core predicate `zero?` would be even more appropriate.
