### PR TITLE
correct indentation in multi-arity examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ when there are no arguments on the same line as the function name.
         (foo x 1))
       ([x y]
         (+ x y)))
-	```
+    ```
 
 * <a name="multiple-arity-order"></a> Sort the arities of a function
   from fewest to most arguments. The common case of multi-arity
@@ -281,18 +281,18 @@ when there are no arguments on the same line as the function name.
     (defn foo
       "I have two arities."
       ([x y]
-        (+ x y))
+       (+ x y))
       ([x]
-        (foo x 1))
-	  ([x y z & more]
-	    (reduce foo (foo x (foo y z)) more)))
-	  
-	;; bad - unordered for no apparent reason
-	(defn foo
-	  ([x] 1)
-	  ([x y z] (foo x (foo y z)))
-	  ([x y] (+ x y))
-	  ([w x y z & more] (reduce foo (foo w (foo x (foo y z))) more)))
+       (foo x 1))
+      ([x y z & more]
+       (reduce foo (foo x (foo y z)) more)))
+
+    ;; bad - unordered for no apparent reason
+    (defn foo
+      ([x] 1)
+      ([x y z] (foo x (foo y z)))
+      ([x y] (+ x y))
+      ([w x y z & more] (reduce foo (foo w (foo x (foo y z))) more)))
     ```
 
 * <a name="align-docstring-lines"></a>


### PR DESCRIPTION
The first multi-arity example shows that an indented body is bad:

```clj
;; bad - extra indentation
(defn foo
  "I have two arities."
  ([x]
    (foo x 1))
  ([x y]
    (+ x y)))
```

But the next example show an "okay" example with the same indentation style:

```clj
;; okay - the other arities are applications of the two-arity 
(defn foo
  "I have two arities."
  ([x y]
    (+ x y))
  ([x]
    (foo x 1))
  ([x y z & more]
    (reduce foo (foo x (foo y z)) more)))
```

I removed the extra indentation in the last example, which I think was related to tab characters sneaking into the file.