### PR TITLE
Fix internal inconsistency regarding usage of pos? predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,14 +881,14 @@ pairwise constructs as found in e.g. `let` and `cond`.
     ```Clojure
     ;; good
     (cond
-      (neg?) "negative"
-      (pos?) "positive"
+      (neg? n) "negative"
+      (pos? n) "positive"
       :else "zero")
 
     ;; bad
     (cond
-      (neg?) "negative"
-      (pos?) "positive"
+      (neg? n) "negative"
+      (pos? n) "positive"
       true "zero")
     ```
 

--- a/README.md
+++ b/README.md
@@ -881,14 +881,14 @@ pairwise constructs as found in e.g. `let` and `cond`.
     ```Clojure
     ;; good
     (cond
-      (< n 0) "negative"
-      (> n 0) "positive"
+      (neg?) "negative"
+      (pos?) "positive"
       :else "zero")
 
     ;; bad
     (cond
-      (< n 0) "negative"
-      (> n 0) "positive"
+      (neg?) "negative"
+      (pos?) "positive"
       true "zero")
     ```
 


### PR DESCRIPTION
The syntax rule regarding usage of pos? and neg?
(https://github.com/bbatsov/clojure-style-guide#pos-and-neg) is not
applied within the example of the syntax rule regarding cond
(https://github.com/bbatsov/clojure-style-guide#else-keyword-in-cond).
This commit updates this example to be consistent with the pos? and neg?
rules.