### PR TITLE
reorganize "test-naming" rule text to follow general rule template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1657,8 +1657,10 @@ in your endeavor to write idiomatic Clojure code.
    `test/yourproject/something_test.clj` (or `.cljc`, `cljs`).
    <sup>[[link](#test-ns-naming)]</sup>
 
- * <a name="test-naming"></a> When using `clojure.test`, define your tests
-   with `deftest` and name them `something-test`. For example:
+ * <a name="test-naming"></a>
+   When using `clojure.test`, define your tests
+   with `deftest` and name them `something-test`.
+   <sup>[[link](#test-naming)]</sup>
 
    ```clojure
    ;; good
@@ -1669,8 +1671,6 @@ in your endeavor to write idiomatic Clojure code.
    (deftest test-something ...)
    (deftest something ...)
    ```
-
-   <sup>[[link](#test-naming)]</sup>
 
 ## Library Organization
 


### PR DESCRIPTION
Hello!
Found out that "test-naming" rule layout was much different from other rules.

Other rules follow this pattern:

````
* <a name="rule-name"></a>
  Rule text.
  <sup>[[link](#rule-name)]</sup>

   ```clojure
   (example)
   ```
````

It's not really a useful change but still:)