### PR TITLE
Character limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,9 @@ macro definition.  An exception can be made to indicate grouping of
 pairwise constructs as found in e.g. `let` and `cond`.
 <sup>[[link](#no-blank-lines-within-def-forms)]</sup>
 
-* <a name="80-character-limits"></a>
-  Where feasible, avoid making lines longer than 80 characters.
-<sup>[[link](#80-character-limits)]</sup>
+* <a name="100-character-limits"></a>
+  Where feasible, avoid making lines longer than 100 characters.
+<sup>[[link](#100-character-limits)]</sup>
 
 * <a name="no-trailing-whitespace"></a>
   Avoid trailing whitespace.


### PR DESCRIPTION
I would suggest a 100 character limit instead of 80, as 100 characters gives a little bit more breathing room while still fitting in GitHub's web-based code editor/viewer and not being (in my opinion) overly long. We have some places in the code (deeply nested `let`s, functions with many params, etc.) where  reducing to an 80-character limit would make the code more difficult to read.

I'm opening this PR to hear people's thoughts on this.