### PR TITLE
Fix "shor forms" typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1034,7 +1034,7 @@ compile-time constants.
   :dunno)
 ----
 
-=== Shor Forms In Cond [[shor-forms-in-cond]]
+=== Short Forms In Cond [[short-forms-in-cond]]
 
 Use short forms in `cond` and related.  If not possible give visual
 hints for the pairwise grouping with comments or empty lines.


### PR DESCRIPTION
Hi! Thanks for creating & maintaining this style guide! I was reading through and noticed a typo in the "Short Forms In Cond" section: https://guide.clojure.style/#shor-forms-in-cond

<img width="361" alt="Screen Shot 2019-06-20 at 11 15 18 PM" src="https://user-images.githubusercontent.com/4165523/59895140-62f18280-93b1-11e9-9d48-88578fb68bbd.png">

This PR fixes the typo in the displayed title and also fixes the same typo in the internal link.

Thanks again for maintaining this guide!