### PR TITLE
Docstring grammar typos and changes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1984,22 +1984,21 @@ can identify them.
 
 === Docstring Grammar [[docstring-grammar]]
 
-Docstrings should be comprised from
-proper English sentences - this means every sentences should start
-with an capitalized word and should end with the proper punctuation. Sentences
-should be separated with a single space.
+Docstrings should be composed of well-formed English sentences. Every sentence 
+should start with a capitalized word, be gramatically coherent, and end 
+with appropriate punctuation. Sentences should be separated with a single space.
 
 [source,clojure]
 ----
 ;; good
 (def foo
   "All sentences should end with a period (or maybe an exclamation mark).
-  And the period should be followed by a space, unless it's the last sentence.")
+  The sentence should be followed by a space, unless it concludes the docstring")
 
 ;; bad
 (def foo
   "all sentences should end with a period (or maybe an exclamation mark).
-  And the period should be followed by a space, unless it's the last sentence")
+  The sentence should be followed by a space, unless it concludes the docstring")
 ----
 
 === Docstring Indentation [[docstring-indentation]]

--- a/README.adoc
+++ b/README.adoc
@@ -1993,12 +1993,12 @@ with appropriate punctuation. Sentences should be separated with a single space.
 ;; good
 (def foo
   "All sentences should end with a period (or maybe an exclamation mark).
-  The sentence should be followed by a space, unless it concludes the docstring")
+  The sentence should be followed by a space, unless it concludes the docstring.")
 
 ;; bad
 (def foo
   "all sentences should end with a period (or maybe an exclamation mark).
-  The sentence should be followed by a space, unless it concludes the docstring")
+  The sentence should be followed by a space, unless it concludes the docstring.")
 ----
 
 === Docstring Indentation [[docstring-indentation]]


### PR DESCRIPTION
This fixes two typos within the docstring grammar block and an error in
conventional usage of the word ‘comprise’.

It also arguably improves the flow of this section.