### PR TITLE
Docstrings: use Markdown, [[links]]; link to GH

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1898,7 +1898,7 @@ If a definition form doesn't support docstrings directly you can still supply th
 the `:doc` metadata attribute.
 
 This section outlines some of the common conventions and best
-practices for documenting Clojure code. Important tools such as [cljdoc](https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#docstrings) support Markdown in docstrings so leverage it.
+practices for documenting Clojure code.
 
 === Prefer Docstrings [[prefer-docstrings]]
 
@@ -1947,6 +1947,32 @@ the docstring at various places.
   "This function does a frobnitz. It will do gnorwatz to
   achieve this, but only under certain circumstances."
   []
+  ...)
+----
+
+=== Leverage Markdown in Docstrings [[markdown-docstrings]]
+
+Important tools such as https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#docstrings[cljdoc] support Markdown in docstrings so leverage it for nicely formatted documentation.
+
+[source,clojure]
+----
+;; good
+(defn qzuf-number
+  "Computes the [Qzuf number](https://wikipedia.org/qzuf) of the `coll`.
+  Supported options in `opts`:
+  
+  | key           | description |
+  | --------------|-------------|
+  | `:finite-uni?`| Assume finite universe; default: `false`
+  | `:complex?`   | If OK to return a [complex number](https://en.wikipedia.org/wiki/Complex_number); default: `false`
+  | `:timeout`    | Throw an exception if the computation doesn't finish within `:timeout` milliseconds; default: `nil`
+  
+  Example:
+  ```clojure
+  (when (neg? (qzuf-number [1 2 3] {:finite-uni? true})) 
+    (throw (RuntimeException. "Error in the Universe!")))
+  ```"
+  [coll opts]
   ...)
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,6 @@
 :idseparator: -
 :sectanchors:
 :sectlinks:
-:toc: preamble
 :toclevels: 1
 ifndef::backend-pdf[]
 :toc-title: pass:[<h2>Table of Contents</h2>]
@@ -1899,7 +1898,7 @@ If a definition form doesn't support docstrings directly you can still supply th
 the `:doc` metadata attribute.
 
 This section outlines some of the common conventions and best
-practices for documenting Clojure code.
+practices for documenting Clojure code. Important tools such as [cljdoc](https://github.com/cljdoc/cljdoc/blob/master/doc/userguide/for-library-authors.adoc#docstrings) support Markdown in docstrings so leverage it.
 
 === Prefer Docstrings [[prefer-docstrings]]
 
@@ -1977,21 +1976,23 @@ functionality for them.
 === Document References [[document-references]]
 
 Wrap any var references in the docstring with ` so that tooling
-can identify them.
+can identify them. Wrap them with `[[..]]` if you want to link to them.
 
 [source,clojure]
 ----
 ;; good
 (defn wombat
   "Acts much like `clojure.core/identity` except when it doesn't.
-  Takes `x` as an argument and returns that. If it feels like it."
+  Takes `x` as an argument and returns that. If it feels like it.
+  See also [[kangaroo]]."
   [x]
   ...)
 
 ;; bad
 (defn wombat
   "Acts much like clojure.core/identity except when it doesn't.
-  Takes `x` as an argument and returns that. If it feels like it."
+  Takes `x` as an argument and returns that. If it feels like it.
+  See also kangaroo."
   [x]
   ...)
 ----
@@ -2166,7 +2167,7 @@ together with everyone interested in Clojure coding style, so that we could
 ultimately create a resource that will be beneficial to the entire Clojure
 community.
 
-Feel free to open tickets or send pull requests with improvements. Thanks in
+Feel free to [open tickets or send pull requests](https://github.com/bbatsov/clojure-style-guide/issues) with improvements. Thanks in
 advance for your help!
 
 You can also support the style guide (and all my Clojure projects like


### PR DESCRIPTION
I think it is worth including the docstring recommendations from Cljdoc ([explained here](https://www.martinklepsch.org/posts/writing-awesome-docstrings.html)) and to encourage people to leverage Markdown for rich content.

Take this as a proposal and feel free to modify to fit better - or discuss.

Also, Contributing should link to GH.