### PR TITLE
confirms the lining up of arguments to threading macros

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -978,6 +978,22 @@ Favor `partial` over anonymous functions for currying.
 
 === Threading Macros [[threading-macros]]
 
+The arguments to the threading macros `+->+` (thread-first) and `+->>+`
+(thread-last) should line up.
+
+[source,clojure]
+----
+;; good
+(->> (range)
+     (filter even?)
+     (take 5))
+
+;; bad
+(->> (range)
+  (filter even?)
+  (take 5))
+----
+
 Prefer the use of the threading macros `+->+` (thread-first) and `+->>+`
 (thread-last) to heavy form nesting.
 


### PR DESCRIPTION
Explicitly confirms, with an example, that the recommended style while using the threading macros is to line up the arguments.