### PR TITLE
Escape quotes in Docstring example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2066,7 +2066,7 @@ Important tools such as https://github.com/cljdoc/cljdoc/blob/master/doc/usergui
   Example:
   ```clojure
   (when (neg? (qzuf-number [1 2 3] {:finite-uni? true}))
-    (throw (RuntimeException. "Error in the Universe!")))
+    (throw (RuntimeException. \"Error in the Universe!\")))
   ```"
   [coll opts]
   ...)


### PR DESCRIPTION
The quotes in the Docstring for the `Leverage Markdown in Docstrings` section need to be escaped. Otherwise the compiler will end the Docstring at the first encountered quote which is not what we want.