### PR TITLE
Fix description for `partial`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1507,7 +1507,7 @@ Favor `comp` over anonymous functions for function composition.
 
 === `partial` [[partial]]
 
-Favor `partial` over anonymous functions for currying.
+Favor `partial` over anonymous functions for partial application.
 
 [source,clojure]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -1507,7 +1507,7 @@ Favor `comp` over anonymous functions for function composition.
 
 === `partial` [[partial]]
 
-Favor `partial` over anonymous functions for partial application.
+Favor `partial` over anonymous functions.
 
 [source,clojure]
 ----


### PR DESCRIPTION
The phrase "for currying" should be fixed.

The meaning of "currying" is actually different.
What we can do with [`partial`](https://clojuredocs.org/clojure.core/partial) is "partial application (of functions)".


## Difference between "partial application" and "currying"  

Suppose there are functions like these:

```clojure
(defn add [x y] (+ x y))

(defn curried-add [x] (fn [y] (+ x y)))

(defn increment [y] (+ 1 y))
```

In the example above,
- "currying" is converting `add` to `curried-add`.
- "partial application" is converting `add` to `increment` (which means, fixing the value of `add`'s nth argument).

