### PR TITLE
Fix typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -962,7 +962,7 @@ unless specified otherwise.
 (def *max-size* 10) ; Common Lisp style, global variable
 ----
 
-NOTE: Famously `*clojure-version*` defies this convention, but you should
+NOTE: Famously `\*clojure-version*` defies this convention, but you should
 treat this naming choice is a historical oddity and not as an example to
 follow.
 


### PR DESCRIPTION
The ear-muffed clojure-version was being interpreted by AsciiDoc as: please bold.
Now escaping leading * so that it renders as expected.