### PR TITLE
Fix mix of present perfect and past tenses

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -873,7 +873,7 @@ are always a better idea.
 Use `lisp-case` in composite namespace segments (e.g. `bruce.project-euler`).
 
 NOTE: Many non-Lisp programming communities refer to `lisp-case` as
-`kebab-case`, but we all know that Lisp has existed way before kebab
+`kebab-case`, but we all know that Lisp existed way before kebab
 was invented.
 
 === Functions and Variables [[naming-functions-and-variables]]


### PR DESCRIPTION
"Has existed" is present perfect, while "was invented" is past
simple. If we remove "has," both become past simple tense.