### PR TITLE
Idiomatic names: k, v, ks, vs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1063,6 +1063,8 @@ Follow ``clojure.core``'s example for idiomatic names like `pred` and `coll`.
  ** `x`, `y` - numbers
  ** `xs` - sequence
  ** `m` - map
+ ** `k`, `ks` - key, keys
+ ** `v`, `vs` - value, values (as in a key/value pair)
  ** `s` - string input
  ** `re` - regular expression
  ** `sym` - symbol


### PR DESCRIPTION
This PR adds two "Idiomatic Names" list entries, to cover `k` and `v` and their plurals. 

In my experience this is one of the most widespread name idioms in Clojure. Some of clojure.core uses the full "key" or "val", but `k`/`ks`/`v`/`vs` are used in many places, such as `dissoc`, `assoc-in`, `get-in`, `update`, `update-in`, and more. I see it frequently in library and project code as well.