### PR TITLE
Use list continuations to fix ordered list numbers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -860,7 +860,7 @@ But what to do about all the other namespaces out there that don't have idiomati
 otherwise the people working on a shared Clojure codebase are going to experience a great deal of confusion. Here are a few rules that you should follow.footnote:[These guidelines are based on a https://stuartsierra.com/2015/05/10/clojure-namespace-aliases[blog post] by Stuart Sierra.]
 
 1. Make the alias the same as the namespace name with the leading parts removed.
-
++
 [source,clojure]
 ----
 (ns com.example.application
@@ -868,19 +868,19 @@ otherwise the people working on a shared Clojure codebase are going to experienc
    [clojure.java.io :as io]
    [clojure.reflect :as reflect]))
 ----
-
++
 2. Keep enough trailing parts to make each alias unique.
-
++
 [source,clojure]
 ----
 [clojure.data.xml :as data.xml]
 [clojure.xml :as xml]
 ----
-
++
 TIP: Yes, namespace aliases can have dots in them. Make good use of them.
-
++
 3. Eliminate redundant words such as "core" and "clj" in aliases.
-
++
 [source,clojure]
 ----
 [clj-time.core :as time]


### PR DESCRIPTION
#### Summary

I noticed the numbering of an ordered list wasn't rendering correctly, so I fixed it. I can see in [this commit](https://github.com/bbatsov/clojure-style-guide/commit/5fb64751a45b828f081948a75683b9ab6e7f0ec5) where you added the numbering to the document to try to fix it. That change could be reverted as well if you prefer to just use `.` for your ordered lists. Let me know if you'd like me to update this PR with that change as well.

Thanks for this great style guide, by the way! +1 for semantic formatting ☺️ 