### PR TITLE
Add `not-empty` example to nil punning section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1312,8 +1312,7 @@ Use `alter-var-root` instead of `def` to change the value of a var.
 
 Use `seq` as a terminating condition to test whether a sequence is
 empty (this technique is sometimes called _nil punning_). You can also
-consider `not-empty`, which behaves exactly the same while clarifying
-your intent.
+consider `not-empty`, which similarly returns nil on an empty sequence.
 
 [source,clojure]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ NOTE: Clojure's developers also maintain a list of
 https://clojure.org/community/contrib_howto#_coding_guidelines[coding
 guidelines for libraries].footnote:[Those guidelines are meant to
 be applied to Clojure itself and to all the Clojure Contrib libraries.]
-They were one of the sources of inspiration for the document, you're
+They were one of the sources of inspiration for the document you're
 currently reading.
 
 ifdef::env-github[]
@@ -1311,13 +1311,20 @@ Use `alter-var-root` instead of `def` to change the value of a var.
 === Nil Punning [[nil-punning]]
 
 Use `seq` as a terminating condition to test whether a sequence is
-empty (this technique is sometimes called _nil punning_).
+empty (this technique is sometimes called _nil punning_). You can also
+consider `not-empty`, which behaves exactly the same while clarifying
+your intent.
 
 [source,clojure]
 ----
 ;; good
 (defn print-seq [s]
   (when (seq s)
+    (prn (first s))
+    (recur (rest s))))
+
+(defn print-seq [s]
+  (when (not-empty s)
     (prn (first s))
     (recur (rest s))))
 


### PR DESCRIPTION
In line with the first given guiding principle:
> Programs must be written for people to read, and only incidentally for machines to execute.
>
> — Harold Abelson
> Structure and Interpretation of Computer Programs

When you want to check that a sequence is empty, you can use `not-empty`. In my opinion, this is easier to read and gives a clearer impression to the reader of what is attempting to be achieved.

`not-empty`'s source is as follows, so there's no significant difference between using `not-empty` or `seq` directly except to make  clearer your intent.
```clj
(defn not-empty
  "If coll is empty, returns nil, else coll"
  {:added "1.0"
   :static true}
  [coll] (when (seq coll) coll))
```

Drive-by: remove errant comma.