### PR TITLE
A rich comment's closing parenthesis may be on the next line (issue #259)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -495,7 +495,7 @@ of commas and line breaks.
 
 === Gather Trailing Parentheses [[gather-trailing-parens]]
 
-Place all trailing parentheses on a single line instead of distinct lines.
+Place trailing parentheses on a single line instead of distinct lines.
 
 [source,clojure]
 ----
@@ -507,6 +507,21 @@ Place all trailing parentheses on a single line instead of distinct lines.
 (when something
   (something-else)
 )
+----
+
+An exception to the rule is a rich comment for REPL-oriented programming,
+lest gathering the comment's closing parenthesis make the last form in the comment harder to use.
+A rich comment's closing parenthesis may be on the next line.
+
+[source,clojure]
+----
+;; good; rich comment ends on the next line
+(comment
+  (range 5)
+  (interpose '* (range 5))
+  (->> (range 5) (interpose '*))
+  (= *1 *2)
+  )
 ----
 
 === Empty Lines Between Top-Level Forms [[empty-lines-between-top-level-forms]]


### PR DESCRIPTION
- Note an exception to the rule "Gather trailing parentheses" as proposed in issue #259.
- Give an example rich comment, based on the motivating case given in issue #259.

Clojure's own source code contains some sequences of expressions
apparently intended for evaluation at the REPL. These are in 
top-level `(comment...)` forms that are invariably closed by 
a parenthesis on a new line: not gathered with the last form 
in the comment.

Some examples:

- https://github.com/clojure/clojure/blob/fb22fd778a272b034684a4ee94509552b46ee8a9/src/clj/clojure/set.clj#L162

- https://github.com/clojure/clojure/blob/fb22fd778a272b034684a4ee94509552b46ee8a9/src/clj/clojure/zip.clj#L281

- https://github.com/clojure/clojure/blob/fb22fd778a272b034684a4ee94509552b46ee8a9/src/clj/clojure/genclass.clj#L726

It is not style, but ergonomics. In REPL-oriented programming, it helps avoid the blunder of evaluating the comment itself when trying to evaluate the last form within it. The ergonomics are within the Style Guide's mission ("to improve the readability of code") because reading Clojure is not just for the eyes, but is also tactile, in the REPL.
